### PR TITLE
Add semantic check passes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 before_script:
   - npm run compile
 script:
+  - npm run lint
   - npm test
 after_success:
   - npm run coverage

--- a/src/diagnostics/diagnostic-bag.ts
+++ b/src/diagnostics/diagnostic-bag.ts
@@ -3,17 +3,13 @@ import { StatementSyntax } from '../ast/statement-syntax';
 import { SyntaxKind } from '../syntax/syntax-kind';
 import { SyntaxToken } from '../syntax/syntax-token';
 import { TextSpan } from '../syntax/text-span';
-import { Source } from '../text/source';
 import { Diagnostic } from './diagnostic';
 import { DiagnosticLevel } from './diagnostic-level';
 
 export class DiagnosticBag {
-  readonly reports: Diagnostic[];
-  readonly source: Source;
-  constructor(source: Source) {
-    this.source = source;
-    this.reports = [];
-  }
+  constructor(
+    private readonly reports: Diagnostic[],
+  ) { }
 
   /**
    * Reports the presence of an unknown character which was
@@ -67,7 +63,6 @@ export class DiagnosticBag {
 
   private report(message: string, span: TextSpan, level: DiagnosticLevel = DiagnosticLevel.Error) {
     this.reports.push({
-      source: this.source,
       message,
       span,
       level,

--- a/src/diagnostics/diagnostic-bag.ts
+++ b/src/diagnostics/diagnostic-bag.ts
@@ -1,3 +1,4 @@
+import { StatementSyntax } from '../ast/statement-syntax';
 import { SyntaxKind } from '../syntax/syntax-kind';
 import { SyntaxToken } from '../syntax/syntax-token';
 import { TextSpan } from '../syntax/text-span';
@@ -35,6 +36,18 @@ export class DiagnosticBag {
     this.report(
       `Unexpected ${SyntaxKind[actual.kind]}. Expected ${SyntaxKind[expected]}`,
       actual.span,
+    );
+  }
+
+  /**
+   * Reports the presence of a statement which is not valid
+   * in the context in which the statement appeared.
+   * @param statement The statement which is out of context.
+   */
+  reportStatementOutOfContext(statement: StatementSyntax) {
+    this.report(
+      'This statement cannot appear in this context.',
+      statement.span,
     );
   }
 

--- a/src/diagnostics/diagnostic-bag.ts
+++ b/src/diagnostics/diagnostic-bag.ts
@@ -1,3 +1,4 @@
+import { ExpressionSyntax } from '../ast/expression-syntax';
 import { StatementSyntax } from '../ast/statement-syntax';
 import { SyntaxKind } from '../syntax/syntax-kind';
 import { SyntaxToken } from '../syntax/syntax-token';
@@ -48,6 +49,19 @@ export class DiagnosticBag {
     this.report(
       'This statement cannot appear in this context.',
       statement.span,
+    );
+  }
+
+  /**
+   * Reports the presence of an expression in a local declaration
+   * list statement which is not supposed to appear in a local
+   * declaration list statement.
+   * @param expression The expression which is wrong.
+   */
+  reportWrongExprInDeclList(expression: ExpressionSyntax) {
+    this.report(
+      'A declaration list can only contain assignment expressions.',
+      expression.span,
     );
   }
 

--- a/src/diagnostics/diagnostic.ts
+++ b/src/diagnostics/diagnostic.ts
@@ -1,9 +1,7 @@
 import { TextSpan } from '../syntax/text-span';
-import { Source } from '../text/source';
 import { DiagnosticLevel } from './diagnostic-level';
 
 export interface Diagnostic {
-  source: Source;
   level: DiagnosticLevel;
   span: TextSpan;
   message: string;

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -108,7 +108,7 @@ function getBinaryOperatorPrecedence(op: SyntaxKind): number {
 
 export class Parser {
 
-  readonly diagnostics: DiagnosticBag;
+  private readonly diagnostics: DiagnosticBag;
   private idx: number;
 
   private readonly tokens: SyntaxToken[];
@@ -126,7 +126,7 @@ export class Parser {
     this.tokens = [];
     this.idx = 0;
     this.source = source;
-    this.diagnostics = new DiagnosticBag(source);
+    this.diagnostics = new DiagnosticBag(source.diagnostics);
   }
 
   async parseRoot(): Promise<SyntaxRoot> {

--- a/src/pass/pass-runner.ts
+++ b/src/pass/pass-runner.ts
@@ -1,0 +1,20 @@
+import { CompilationUnit } from '../program/compilation-unit';
+import { PassConstructor } from './pass';
+
+export class PassRunner {
+
+  constructor(
+    private readonly passes: PassConstructor[],
+  ) {
+
+  }
+
+  run(units: CompilationUnit[]) {
+    return Promise.all(units.map((unit) => {
+      return Promise.all(this.passes.map((pass) => {
+        const passInstance = new pass(unit);
+        return passInstance.run();
+      }));
+    }));
+  }
+}

--- a/src/pass/pass.ts
+++ b/src/pass/pass.ts
@@ -1,0 +1,7 @@
+import { CompilationUnit } from '../program/compilation-unit';
+
+export type PassConstructor = new (unit: CompilationUnit) => Pass;
+
+export interface Pass {
+  run(): Promise<void>;
+}

--- a/src/program/compilation-unit.ts
+++ b/src/program/compilation-unit.ts
@@ -12,7 +12,7 @@ export class CompilationUnit {
 
   constructor(source: Source) {
     this.source = source;
-    this.diagnostics = new DiagnosticBag(source);
+    this.diagnostics = new DiagnosticBag(source.diagnostics);
   }
 
   async syntaxRoot(): Promise<Readonly<SyntaxRoot>> {

--- a/src/program/compilation-unit.ts
+++ b/src/program/compilation-unit.ts
@@ -1,4 +1,3 @@
-import { Diagnostic } from '../diagnostics/diagnostic';
 import { DiagnosticBag } from '../diagnostics/diagnostic-bag';
 import { Parser } from '../parser/parser';
 import { SyntaxRoot } from '../parser/syntax-root';
@@ -7,16 +6,13 @@ import { Source } from '../text/source';
 export class CompilationUnit {
 
   readonly source: Source;
-  get diagnostics(): ReadonlyArray<Diagnostic> {
-    return this.diagnosticBag.reports;
-  }
 
-  private readonly diagnosticBag: DiagnosticBag;
+  readonly diagnostics: DiagnosticBag;
   private root: SyntaxRoot | undefined;
 
   constructor(source: Source) {
     this.source = source;
-    this.diagnosticBag = new DiagnosticBag(source);
+    this.diagnostics = new DiagnosticBag(source);
   }
 
   async syntaxRoot(): Promise<Readonly<SyntaxRoot>> {

--- a/src/semantic/check-context.ts
+++ b/src/semantic/check-context.ts
@@ -1,0 +1,41 @@
+import { Pass } from '../pass/pass';
+import { CompilationUnit } from '../program/compilation-unit';
+import { SyntaxKind } from '../syntax/syntax-kind';
+import { SyntaxNode } from '../syntax/syntax-node';
+
+export class CheckContext implements Pass {
+
+  constructor(
+    readonly unit: CompilationUnit,
+  ) { }
+
+  async run(): Promise<void> {
+    const root = await this.unit.syntaxRoot();
+    root.forEachChild((child) => {
+      switch (child.kind) {
+        case SyntaxKind.BreakStatement:
+          if (!this.isInLoop(child) && !child.isChildOf(SyntaxKind.SwitchStatement)) {
+            this.unit.diagnostics.reportStatementOutOfContext(child);
+          }
+          break;
+        case SyntaxKind.ContinueStatement:
+          if (!this.isInLoop(child)) {
+            this.unit.diagnostics.reportStatementOutOfContext(child);
+          }
+          break;
+        case SyntaxKind.DefaultStatement:
+        case SyntaxKind.CaseStatement:
+          if (!child.isChildOf(SyntaxKind.SwitchStatement)) {
+            this.unit.diagnostics.reportStatementOutOfContext(child);
+          }
+      }
+    });
+  }
+
+  private isInLoop(node: SyntaxNode): boolean {
+    const inForLoop = node.isChildOf(SyntaxKind.ForStatement);
+    const inWhileLoop = node.isChildOf(SyntaxKind.WhileStatement);
+    const inDoLoop = node.isChildOf(SyntaxKind.DoStatement);
+    return inForLoop || inWhileLoop || inDoLoop;
+  }
+}

--- a/src/semantic/check-declaration-list.ts
+++ b/src/semantic/check-declaration-list.ts
@@ -25,11 +25,11 @@ export class CheckDeclarationList implements Pass {
             case SyntaxKind.BinaryExpression:
               const binOp = decl as BinaryExpression;
               if (binOp.opToken.kind !== SyntaxKind.Equals) {
-                this.unit.diagnostics.reportLocalDeclarationListWrongExpression(decl);
+                this.unit.diagnostics.reportWrongExprInDeclList(decl);
               }
               break;
             default:
-              this.unit.diagnostics.reportLocalDeclarationListWrongExpression(decl);
+              this.unit.diagnostics.reportWrongExprInDeclList(decl);
           }
         }
       }

--- a/src/semantic/check-declaration-list.ts
+++ b/src/semantic/check-declaration-list.ts
@@ -1,0 +1,38 @@
+import { BinaryExpression } from '../ast/binary-expression';
+import { LocalDeclarationListStatement } from '../ast/local-declaration-list-statement';
+import { Pass } from '../pass/pass';
+import { CompilationUnit } from '../program/compilation-unit';
+import { SyntaxKind } from '../syntax/syntax-kind';
+
+export class CheckDeclarationList implements Pass {
+
+  constructor(
+    readonly unit: CompilationUnit,
+  ) { }
+
+  async run(): Promise<void> {
+    const root = await this.unit.syntaxRoot();
+    root.forEachChild((child) => {
+      if (child.kind === SyntaxKind.LocalDeclarationListStatement) {
+        const declList = child as LocalDeclarationListStatement;
+        for (const decl of declList.declarations) {
+          if (decl.kind < SyntaxKind.LastToken) {
+            continue;
+          }
+          switch (decl.kind) {
+            case SyntaxKind.IdentifierExpression:
+              continue;
+            case SyntaxKind.BinaryExpression:
+              const binOp = decl as BinaryExpression;
+              if (binOp.opToken.kind !== SyntaxKind.Equals) {
+                this.unit.diagnostics.reportLocalDeclarationListWrongExpression(decl);
+              }
+              break;
+            default:
+              this.unit.diagnostics.reportLocalDeclarationListWrongExpression(decl);
+          }
+        }
+      }
+    });
+  }
+}

--- a/src/syntax/syntax-node.ts
+++ b/src/syntax/syntax-node.ts
@@ -18,4 +18,16 @@ export abstract class SyntaxNode {
    * The parent of this node.
    */
   parent: SyntaxNode | undefined;
+
+  isChildOf(kind: SyntaxKind): boolean {
+    let current = this.parent;
+    while (current !== undefined) {
+      if (current.kind === kind) {
+        return true;
+      } else {
+        current = current.parent;
+      }
+    }
+    return false;
+  }
 }

--- a/src/text/source-file.ts
+++ b/src/text/source-file.ts
@@ -1,14 +1,18 @@
 import { basename } from 'path';
+import { Diagnostic } from '../diagnostics/diagnostic';
 import { readFile } from '../util/fs';
 import { Source } from './source';
 
 export class SourceFile implements Source {
+
+  readonly diagnostics: Diagnostic[];
   readonly name: string;
   readonly filePath: string;
   private fileContents: string | undefined;
   constructor(filePath: string) {
     this.filePath = filePath;
     this.name = basename(filePath);
+    this.diagnostics = [];
   }
 
   async contents(): Promise<string> {

--- a/src/text/source-text.ts
+++ b/src/text/source-text.ts
@@ -1,10 +1,14 @@
+import { Diagnostic } from '../diagnostics/diagnostic';
 import { Source } from './source';
 
 export class SourceText implements Source {
+  readonly diagnostics: Diagnostic[];
   constructor(
     readonly name: string,
     private readonly source: string,
-  ) { }
+  ) {
+    this.diagnostics = [];
+  }
 
   contents(): Promise<string> {
     return Promise.resolve(this.source);

--- a/src/text/source.ts
+++ b/src/text/source.ts
@@ -1,4 +1,7 @@
+import { Diagnostic } from '../diagnostics/diagnostic';
+
 export interface Source {
   name: string;
+  diagnostics: Diagnostic[];
   contents(): Promise<string>;
 }

--- a/test/parser/binary-ops.spec.ts
+++ b/test/parser/binary-ops.spec.ts
@@ -6,7 +6,7 @@ import { TerminatedStatement } from '../../src/ast/terminated-statement';
 import { Parser } from '../../src/parser/parser';
 import { SyntaxRoot } from '../../src/parser/syntax-root';
 import { SyntaxKind } from '../../src/syntax/syntax-kind';
-import { source } from '../util';
+import { createSource } from '../util';
 
 function unwrap(root: SyntaxRoot): BinaryExpression {
   return ((root.statements[0] as TerminatedStatement)
@@ -17,12 +17,12 @@ function unwrap(root: SyntaxRoot): BinaryExpression {
 describe('Parser', () => {
   describe('binary operations.', () => {
     it('should be able to parse binary operation expressions.', async () => {
-      const parser = new Parser(source('1 + 2;'));
+      const parser = new Parser(createSource('1 + 2;'));
       const root = await parser.parseRoot();
       expect(unwrap(root).kind).to.equal(SyntaxKind.BinaryExpression);
     });
     it('should have the correct order of operations.', async () => {
-      const parser = new Parser(source('1 + 2 - 3 * 5;'));
+      const parser = new Parser(createSource('1 + 2 - 3 * 5;'));
       const root = await parser.parseRoot();
       // the higher precedence operators should be lower down in the tree.
       const rightOp = (unwrap(root).right as BinaryExpression).opToken.kind;
@@ -32,27 +32,27 @@ describe('Parser', () => {
       expect(unwrap(root).opToken.kind).to.equal(SyntaxKind.Minus);
     });
     it('should not bind as tightly as unary operations.', async () => {
-      const parser = new Parser(source('-1 + ~2;'));
+      const parser = new Parser(createSource('-1 + ~2;'));
       const root = await parser.parseRoot();
       expect(unwrap(root).kind).to.equal(SyntaxKind.BinaryExpression);
     });
     it('should not bind as tightly as function calls.', async () => {
-      const parser = new Parser(source('a() - b();'));
+      const parser = new Parser(createSource('a() - b();'));
       const root = await parser.parseRoot();
       expect(unwrap(root).kind).to.equal(SyntaxKind.BinaryExpression);
     });
     it('should not bind as tightly as accessors.', async () => {
-      const parser = new Parser(source('a[| 1] - b[3, 5] * c[? "test"]'));
+      const parser = new Parser(createSource('a[| 1] - b[3, 5] * c[? "test"]'));
       const root = await parser.parseRoot();
       expect(unwrap(root).kind).to.equal(SyntaxKind.BinaryExpression);
     });
     it('should not bind as tightly as parenthesised expressions.', async () => {
-      const parser = new Parser(source('(1 + 2) * 3;'));
+      const parser = new Parser(createSource('(1 + 2) * 3;'));
       const root = await parser.parseRoot();
       expect(unwrap(root).opToken.kind).to.equal(SyntaxKind.Star);
     });
     it('should not bind as tightly as prefix or postfix operations.', async () => {
-      const parser = new Parser(source('--a + b++;'));
+      const parser = new Parser(createSource('--a + b++;'));
       const root = await parser.parseRoot();
       expect(unwrap(root).kind).to.equal(SyntaxKind.BinaryExpression);
     });

--- a/test/parser/parser.spec.ts
+++ b/test/parser/parser.spec.ts
@@ -283,7 +283,7 @@ describe('Parser', () => {
     const program = new Program(FILE_DIR);
     await program.getSourceFiles();
     const result = await program.emit();
-    const sum = result.reduce((sum, unit) => sum + unit.diagnostics.length, 0);
+    const sum = result.reduce((sum, unit) => sum + unit.diagnostics.reports.length, 0);
     expect(sum).to.equal(0);
   });
 });

--- a/test/parser/parser.spec.ts
+++ b/test/parser/parser.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import { join } from 'path';
 import { Parser } from '../../src/parser/parser';
 import { Program } from '../../src/program/program';
-import { source } from '../util';
+import { createSource } from '../util';
 
 // examples are taken from the GML reference doc
 // https://docs.yoyogames.com/source/dadiospice/002_reference/001_gml%20language%20overview/
@@ -236,43 +236,45 @@ if inst != noone target = inst;
 describe('Parser', () => {
   for (let i = 0; i < EXAMPLES.length; i++) {
     it(`should parse example #${i}`, async () => {
-      const parser = new Parser(source(EXAMPLES[i]));
+      const source = createSource(EXAMPLES[i]);
+      const parser = new Parser(source);
       await parser.parseRoot();
-      expect(parser.diagnostics.reports.length).to.equal(0);
+      expect(source.diagnostics.length).to.equal(0);
     });
   }
   it('should report a diagnostic if an unexpected token is encountered.', async () => {
-    const parser = new Parser(source('if > 10 break;'));
+    const source = createSource('if > 10 break;');
+    const parser = new Parser(source);
     await parser.parseRoot();
-    expect(parser.diagnostics.reports.length).to.be.greaterThan(0);
+    expect(source.diagnostics.length).to.be.greaterThan(0);
   });
   it('should not get stuck while parsing an array index expression.', async () => {
-    const parser = new Parser(source('test[if for while'));
+    const parser = new Parser(createSource('test[if for while'));
     const result = await parser.parseRoot();
     expect(result).not.to.equal(undefined);
   });
   it('should not get stuck while parsing an array access expression.', async () => {
-    const parser = new Parser(source('test[@if for while'));
+    const parser = new Parser(createSource('test[@if for while'));
     const result = await parser.parseRoot();
     expect(result).not.to.equal(undefined);
   });
   it('should not get stuck while parsing a call expression.', async () => {
-    const parser = new Parser(source('test(if for while'));
+    const parser = new Parser(createSource('test(if for while'));
     const result = await parser.parseRoot();
     expect(result).not.to.equal(undefined);
   });
   it('should not get stuck while parsing a switch statement.', async () => {
-    const parser = new Parser(source('switch (test) {💡💡💡'));
+    const parser = new Parser(createSource('switch (test) {💡💡💡'));
     const result = await parser.parseRoot();
     expect(result).not.to.equal(undefined);
   });
   it('should not get stuck while parsing a block statement.', async () => {
-    const parser = new Parser(source('{💡💡💡'));
+    const parser = new Parser(createSource('{💡💡💡'));
     const result = await parser.parseRoot();
     expect(result).not.to.equal(undefined);
   });
   it('should not get stuck while parsing a script.', async () => {
-    const parser = new Parser(source('💡💡💡'));
+    const parser = new Parser(createSource('💡💡💡'));
     const result = await parser.parseRoot();
     expect(result).not.to.equal(undefined);
   });
@@ -283,7 +285,7 @@ describe('Parser', () => {
     const program = new Program(FILE_DIR);
     await program.getSourceFiles();
     const result = await program.emit();
-    const sum = result.reduce((sum, unit) => sum + unit.diagnostics.reports.length, 0);
+    const sum = result.reduce((sum, unit) => sum + unit.source.diagnostics.length, 0);
     expect(sum).to.equal(0);
   });
 });

--- a/test/parser/syntax-root.spec.ts
+++ b/test/parser/syntax-root.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import { Parser } from '../../src/parser/parser';
 import { SyntaxKind } from '../../src/syntax/syntax-kind';
 import { SyntaxToken } from '../../src/syntax/syntax-token';
-import { source } from '../util';
+import { createSource } from '../util';
 
 const SCRIPT_CONTENTS = `with (instance_create(x, y, obj_Ball))
 {
@@ -15,7 +15,7 @@ const SCRIPT_CONTENTS = `with (instance_create(x, y, obj_Ball))
 describe('SyntaxRoot', () => {
   describe('#forEachChild()', () => {
     it('should visit every child of every subtree.', async () => {
-      const parser = new Parser(source(SCRIPT_CONTENTS));
+      const parser = new Parser(createSource(SCRIPT_CONTENTS));
       const root = await parser.parseRoot();
       let result = '';
       root.forEachChild((child) => {

--- a/test/semantic/check-context.spec.ts
+++ b/test/semantic/check-context.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import 'mocha';
+import { PassRunner } from '../../src/pass/pass-runner';
+import { CompilationUnit } from '../../src/program/compilation-unit';
+import { CheckContext } from '../../src/semantic/check-context';
+import { source } from '../util';
+
+async function getReportCount(src: string): Promise<number> {
+  const unit = new CompilationUnit(source(src));
+  // parse the AST now to avoid counting parse diagnostics later
+  await unit.syntaxRoot();
+  const before = unit.diagnostics.reports.length;
+  const runner = new PassRunner([CheckContext]);
+  await runner.run([unit]);
+  return unit.diagnostics.reports.length - before;
+}
+
+describe('CheckContext', () => {
+  describe('break statement checks.', () => {
+    it('should report a diagnostic if a break statement appears outside of a loop.', async () => {
+      const count = await getReportCount('break;');
+      expect(count).to.be.greaterThan(0);
+    });
+    it('should not report a diagnostic if a break statement appears in a switch statement.', async () => {
+      const count = await getReportCount('switch (value) { default: break; }');
+      expect(count).to.equal(0);
+    });
+    it('should not report a diagnostic if a break statement appears in a for loop.', async () => {
+      const count = await getReportCount('for (var i = 0; i < 10; i++) { if (i > 2) { break; } }');
+      expect(count).to.equal(0);
+    });
+    it('should not report a diagnostic if a break statement appears in a while loop.', async () => {
+      const count = await getReportCount('while (true) { if (irandom(10) < 5) break; }');
+      expect(count).to.equal(0);
+    });
+    it('should not report a diagnostic if a break statement appears in a do loop.', async () => {
+      const count = await getReportCount('do { break; } until (false);');
+      expect(count).to.equal(0);
+    });
+  });
+  describe('continue statement checks.', () => {
+    it('should report a diagnostic if a continue statement appears outside of a loop.', async () => {
+      const count = await getReportCount('if true { continue; }');
+      expect(count).to.be.greaterThan(0);
+    });
+    it('should not report a diagnostic if a continue statement appears in a for loop.', async () => {
+      const count = await getReportCount('for (var i = 0; i < 10; i++) { if (i > 2) { continue; } }');
+      expect(count).to.equal(0);
+    });
+    it('should not report a diagnostic if a continue statement appears in a while loop.', async () => {
+      const count = await getReportCount('while (true) { if (irandom(10) < 5) continue; }');
+      expect(count).to.equal(0);
+    });
+    it('should not report a diagnostic if a continue statement appears in a do loop.', async () => {
+      const count = await getReportCount('do { continue; } until (false);');
+      expect(count).to.equal(0);
+    });
+  });
+  describe('switch statement checks.', () => {
+    it('should report a diagnostic if a default statement appears outside of a switch statement.', async () => {
+      const count = await getReportCount('if (true) { default: print("hello"); }');
+      expect(count).to.be.greaterThan(0);
+    });
+    it('should report a diagnostic if a case statement appears outside of a switch statement.', async () => {
+      const count = await getReportCount('case 10: return "world";');
+      expect(count).to.be.greaterThan(0);
+    });
+  });
+});

--- a/test/semantic/check-context.spec.ts
+++ b/test/semantic/check-context.spec.ts
@@ -1,68 +1,58 @@
 import { expect } from 'chai';
 import 'mocha';
-import { PassRunner } from '../../src/pass/pass-runner';
-import { CompilationUnit } from '../../src/program/compilation-unit';
 import { CheckContext } from '../../src/semantic/check-context';
-import { source } from '../util';
+import { getReportCounter } from '../util';
 
-async function getReportCount(src: string): Promise<number> {
-  const unit = new CompilationUnit(source(src));
-  // parse the AST now to avoid counting parse diagnostics later
-  await unit.syntaxRoot();
-  const before = unit.diagnostics.reports.length;
-  const runner = new PassRunner([CheckContext]);
-  await runner.run([unit]);
-  return unit.diagnostics.reports.length - before;
-}
+const reportCounter = getReportCounter(CheckContext);
 
 describe('CheckContext', () => {
   describe('break statement checks.', () => {
     it('should report a diagnostic if a break statement appears outside of a loop.', async () => {
-      const count = await getReportCount('break;');
+      const count = await reportCounter('break;');
       expect(count).to.be.greaterThan(0);
     });
     it('should not report a diagnostic if a break statement appears in a switch statement.', async () => {
-      const count = await getReportCount('switch (value) { default: break; }');
+      const count = await reportCounter('switch (value) { default: break; }');
       expect(count).to.equal(0);
     });
     it('should not report a diagnostic if a break statement appears in a for loop.', async () => {
-      const count = await getReportCount('for (var i = 0; i < 10; i++) { if (i > 2) { break; } }');
+      const count = await reportCounter('for (var i = 0; i < 10; i++) { if (i > 2) { break; } }');
       expect(count).to.equal(0);
     });
     it('should not report a diagnostic if a break statement appears in a while loop.', async () => {
-      const count = await getReportCount('while (true) { if (irandom(10) < 5) break; }');
+      const count = await reportCounter('while (true) { if (irandom(10) < 5) break; }');
       expect(count).to.equal(0);
     });
     it('should not report a diagnostic if a break statement appears in a do loop.', async () => {
-      const count = await getReportCount('do { break; } until (false);');
+      const count = await reportCounter('do { break; } until (false);');
       expect(count).to.equal(0);
     });
   });
   describe('continue statement checks.', () => {
     it('should report a diagnostic if a continue statement appears outside of a loop.', async () => {
-      const count = await getReportCount('if true { continue; }');
+      const count = await reportCounter('if true { continue; }');
       expect(count).to.be.greaterThan(0);
     });
     it('should not report a diagnostic if a continue statement appears in a for loop.', async () => {
-      const count = await getReportCount('for (var i = 0; i < 10; i++) { if (i > 2) { continue; } }');
+      const count = await reportCounter('for (var i = 0; i < 10; i++) { if (i > 2) { continue; } }');
       expect(count).to.equal(0);
     });
     it('should not report a diagnostic if a continue statement appears in a while loop.', async () => {
-      const count = await getReportCount('while (true) { if (irandom(10) < 5) continue; }');
+      const count = await reportCounter('while (true) { if (irandom(10) < 5) continue; }');
       expect(count).to.equal(0);
     });
     it('should not report a diagnostic if a continue statement appears in a do loop.', async () => {
-      const count = await getReportCount('do { continue; } until (false);');
+      const count = await reportCounter('do { continue; } until (false);');
       expect(count).to.equal(0);
     });
   });
   describe('switch statement checks.', () => {
     it('should report a diagnostic if a default statement appears outside of a switch statement.', async () => {
-      const count = await getReportCount('if (true) { default: print("hello"); }');
+      const count = await reportCounter('if (true) { default: print("hello"); }');
       expect(count).to.be.greaterThan(0);
     });
     it('should report a diagnostic if a case statement appears outside of a switch statement.', async () => {
-      const count = await getReportCount('case 10: return "world";');
+      const count = await reportCounter('case 10: return "world";');
       expect(count).to.be.greaterThan(0);
     });
   });

--- a/test/semantic/check-declaration-list.spec.ts
+++ b/test/semantic/check-declaration-list.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import 'mocha';
+import { CheckDeclarationList } from '../../src/semantic/check-declaration-list';
+import { getReportCounter } from '../util';
+
+const reportCounter = getReportCounter(CheckDeclarationList);
+
+describe('CheckDeclarationList', () => {
+  describe('local declaration checks.', () => {
+    it('should report a diagnostic if an expression other than assignment or identifier is used.', async () => {
+      const count = await reportCounter('var test = 10, 1 + 2, b;');
+      expect(count).to.equal(1);
+    });
+    it('should not report a diagnostic if only identifiers are used.', async () => {
+      const count = await reportCounter('var a, b, c;');
+      expect(count).to.equal(0);
+    });
+    it('should not report a diagnostic if only assignment expressions are used.', async () => {
+      const count = await reportCounter('var a = 10, b = 20, c = 30;');
+      expect(count).to.equal(0);
+    });
+    it('should not report a diagnostic if only either are used.', async () => {
+      const count = await reportCounter('var a, b = 10, c, d = 20;');
+      expect(count).to.equal(0);
+    });
+    it('should report a diagnostic if neither are used.', async () => {
+      const count = await reportCounter('var 1 + 2, test();');
+      expect(count).to.be.equal(2);
+    });
+  });
+});

--- a/test/syntax/lexer.spec.ts
+++ b/test/syntax/lexer.spec.ts
@@ -31,7 +31,7 @@ a[@ i] = 100;
 `;
 
 const testSource = new SourceFile('test');
-const diagnosticBag = new DiagnosticBag(testSource);
+const diagnosticBag = new DiagnosticBag(testSource.diagnostics);
 
 describe('Lexer', () => {
   describe('#tokens()', () => {
@@ -128,9 +128,9 @@ describe('Lexer', () => {
     });
     it('should report a diagnostic for unknown tokens.', () => {
       const lexer = new Lexer('💡', diagnosticBag);
-      const before = diagnosticBag.reports.length;
+      const before = testSource.diagnostics.length;
       lexer.tokens();
-      const after = diagnosticBag.reports.length;
+      const after = testSource.diagnostics.length;
       expect(after).to.be.greaterThan(before);
     });
   });

--- a/test/syntax/syntax-node.spec.ts
+++ b/test/syntax/syntax-node.spec.ts
@@ -2,12 +2,12 @@ import { expect } from 'chai';
 import 'mocha';
 import { Parser } from '../../src/parser/parser';
 import { SyntaxKind } from '../../src/syntax/syntax-kind';
-import { source } from '../util';
+import { createSource } from '../util';
 
 describe('SyntaxNode', () => {
   describe('#isChildOf()', () => {
     it('should return true if the syntax node is a child of the specified node kind.', async () => {
-      const parser = new Parser(source('while (true) { if (false) { exit; } }'));
+      const parser = new Parser(createSource('while (true) { if (false) { exit; } }'));
       const root = await parser.parseRoot();
       root.forEachChild((child) => {
         if (child.kind === SyntaxKind.Exit) {
@@ -17,7 +17,7 @@ describe('SyntaxNode', () => {
       });
     });
     it('should return false if the syntax node is not a child of the specified node kind.', async () => {
-      const parser = new Parser(source('while (true) { if (false) { exit; } }'));
+      const parser = new Parser(createSource('while (true) { if (false) { exit; } }'));
       const root = await parser.parseRoot();
       root.forEachChild((child) => {
         if (child.kind === SyntaxKind.Exit) {

--- a/test/syntax/syntax-node.spec.ts
+++ b/test/syntax/syntax-node.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import 'mocha';
+import { Parser } from '../../src/parser/parser';
+import { SyntaxKind } from '../../src/syntax/syntax-kind';
+import { source } from '../util';
+
+describe('SyntaxNode', () => {
+  describe('#isChildOf()', () => {
+    it('should return true if the syntax node is a child of the specified node kind.', async () => {
+      const parser = new Parser(source('while (true) { if (false) { exit; } }'));
+      const root = await parser.parseRoot();
+      root.forEachChild((child) => {
+        if (child.kind === SyntaxKind.Exit) {
+          expect(child.isChildOf(SyntaxKind.WhileStatement)).to.equal(true);
+          expect(child.isChildOf(SyntaxKind.IfStatement)).to.equal(true);
+        }
+      });
+    });
+    it('should return false if the syntax node is not a child of the specified node kind.', async () => {
+      const parser = new Parser(source('while (true) { if (false) { exit; } }'));
+      const root = await parser.parseRoot();
+      root.forEachChild((child) => {
+        if (child.kind === SyntaxKind.Exit) {
+          expect(child.isChildOf(SyntaxKind.DoStatement)).to.equal(false);
+        }
+      });
+    });
+  });
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -4,20 +4,20 @@ import { CompilationUnit } from '../src/program/compilation-unit';
 import { Source } from '../src/text/source';
 import { SourceText } from '../src/text/source-text';
 
-export function source(src: string): Source {
+export function createSource(src: string): Source {
   return new SourceText('test-script', src);
 }
 
 type ReportCounterFn = (src: string) => Promise<number>;
 export function getReportCounter(...passes: PassConstructor[]): ReportCounterFn {
   return async (src: string) => {
-    const unit = new CompilationUnit(source(src));
+    const unit = new CompilationUnit(createSource(src));
     // parse the AST now to avoid counting parse diagnostics later
     await unit.syntaxRoot();
-    const before = unit.diagnostics.reports.length;
+    const before = unit.source.diagnostics.length;
     const runner = new PassRunner(passes);
     await runner.run([unit]);
     // console.log(unit.diagnostics.reports);
-    return unit.diagnostics.reports.length - before;
+    return unit.source.diagnostics.length - before;
   };
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -19,5 +19,5 @@ export function getReportCounter(...passes: PassConstructor[]): ReportCounterFn 
     await runner.run([unit]);
     // console.log(unit.diagnostics.reports);
     return unit.diagnostics.reports.length - before;
-  }
+  };
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,6 +1,23 @@
+import { PassConstructor } from '../src/pass/pass';
+import { PassRunner } from '../src/pass/pass-runner';
+import { CompilationUnit } from '../src/program/compilation-unit';
 import { Source } from '../src/text/source';
 import { SourceText } from '../src/text/source-text';
 
 export function source(src: string): Source {
   return new SourceText('test-script', src);
+}
+
+type ReportCounterFn = (src: string) => Promise<number>;
+export function getReportCounter(...passes: PassConstructor[]): ReportCounterFn {
+  return async (src: string) => {
+    const unit = new CompilationUnit(source(src));
+    // parse the AST now to avoid counting parse diagnostics later
+    await unit.syntaxRoot();
+    const before = unit.diagnostics.reports.length;
+    const runner = new PassRunner(passes);
+    await runner.run([unit]);
+    // console.log(unit.diagnostics.reports);
+    return unit.diagnostics.reports.length - before;
+  }
 }


### PR DESCRIPTION
Because of the more "relaxed" nature of the parser, some abstract syntax trees may be parsed successfully, but may not be semantically valid. Some examples include

+ [x] Break/continue statements appearing outside of a loop or switch statement.
+ [x] Local declaration lists where the list contains expressions other than assignment expressions.
+ [ ] For loops that do not use a declaration (with an assignment) as the first statement.

This pull request will be merged when all of these cases are being checked for and reported as a diagnostic if they are found.